### PR TITLE
Support dot separated repository name

### DIFF
--- a/internal/workers/trigger_actions.go
+++ b/internal/workers/trigger_actions.go
@@ -16,7 +16,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var triggerActionsExp = regexp.MustCompile(`(?P<org>[^\/]+)\/(?P<repo>[\w\-\_\.]+)[^\w]+(?P<task>[\w\-\_]+)[^\w]+branch:(?P<branch>[\w\-\_]+)`)
+var commonRegexp = `\w\-\_\.`
+var triggerActionsExp = regexp.MustCompile(`(?P<org>[^\/]+)\/(?P<repo>[` + commonRegexp + `]+)[^\w]+(?P<task>[` + commonRegexp + `]+)[^\w]+branch:(?P<branch>[` + commonRegexp + `]+)`)
 
 type TriggerActionsParams struct {
 	Event *slackevents.AppMentionEvent

--- a/internal/workers/trigger_actions.go
+++ b/internal/workers/trigger_actions.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var triggerActionsExp = regexp.MustCompile(`(?P<org>[^\/]+)\/(?P<repo>[\w\-\_]+)[^\w]+(?P<task>[\w\-\_]+)[^\w]+branch:(?P<branch>[\w\-\_]+)`)
+var triggerActionsExp = regexp.MustCompile(`(?P<org>[^\/]+)\/(?P<repo>[\w\-\_\.]+)[^\w]+(?P<task>[\w\-\_]+)[^\w]+branch:(?P<branch>[\w\-\_]+)`)
 
 type TriggerActionsParams struct {
 	Event *slackevents.AppMentionEvent


### PR DESCRIPTION
Our repository of some includes dot, so I want to add dot support regexp for repository name.
e.g. `org/repo.xx`