### PR TITLE
Fix the return value of capLock

### DIFF
--- a/internal/workers/trigger_actions.go
+++ b/internal/workers/trigger_actions.go
@@ -91,7 +91,7 @@ func canLock(ctx context.Context, key, value, ttl string) (bool, string, string,
 
 		return v == value, v, expireAt, nil
 	}
-	return true, expireAt, value, nil
+	return true, value, expireAt, nil
 }
 
 func unlock(ctx context.Context, key string, result map[string]string, cfg *config, param *TriggerActionsParams, api *slack.Client) error {


### PR DESCRIPTION
capLock の返り値の一部が誤った順番だったので修正します

この使用部分を元に修正しています。

```
getLock, lockValue, expireAt, err := canLock(ctx, key, result[cfg.LockValueParamsKey], result[cfg.LockTTLParamsKey])
```


https://github.com/yoshikouki/github-actions-trigger-bot/blob/fix-canLock/internal/workers/trigger_actions.go#L182:L182


