### PR TITLE
parseTriggerMessage: for parameters containing `:` ( parseTriggerMessage: `:` を含むパラメータに対応する )

### DIFF
--- a/internal/workers/trigger_actions.go
+++ b/internal/workers/trigger_actions.go
@@ -57,7 +57,7 @@ func parseTriggerMessage(text string) map[string]string {
 	}
 	for _, v := range match {
 		if strings.Index(v[0], ":") > 0 {
-			kv := strings.Split(v[0], ":")
+			kv := strings.SplitN(v[0], ":", 2)
 			result[kv[0]] = kv[1]
 		}
 	}

--- a/internal/workers/trigger_actions_test.go
+++ b/internal/workers/trigger_actions_test.go
@@ -40,6 +40,16 @@ func Test_parseTriggerMessage(t *testing.T) {
 				"hoge": "fuga",
 			},
 		},
+		{
+			name: "ok",
+			text: "org/repo task email:<mailto:test@example.com>",
+			want: map[string]string{
+				"org":   "org",
+				"repo":  "repo",
+				"task":  "task",
+				"email": "<mailto:test@example.com>",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Hello pyama!

When you enter an email address in slack, there is an automatic markup behavior (e.g. `test@example.com` -> `<mailto:test@example.com>` ) 

![image](https://github.com/pyama86/github-actions-trigger-bot/assets/172456/d5f67717-ab1e-40e0-b440-91f842537e5e)

In such a case, I modified the code so that the string is split as intended by the user, even when a parameter containing `:` is passed to parseTriggerMessage.

----

## 日本語
 
こんにちわ pyama さん

slack でメールアドレスを入力すると、自動でマークアップする振る舞いがあります (e.g. `test@example.com` -> `<mailto:test@example.com>` ) 

このようなケースで parseTriggerMessage に : を含むパラメーターを渡した時にも、ユーザが意図したように文字列が split されるようにコードを改修しました。

